### PR TITLE
Getting latest

### DIFF
--- a/source/DropDownButtonLib/Controls/DropDownButton.xaml.cs
+++ b/source/DropDownButtonLib/Controls/DropDownButton.xaml.cs
@@ -432,7 +432,8 @@ namespace DropDownButtonLib.Controls
     /// <param name="e"></param>
     private void OnMouseDownOutsideCapturedElement(object sender, MouseButtonEventArgs e)
     {
-      this.CloseDropDown(false);
+      if( !IsMouseOver )
+        CloseDropDown( true );
     }
 
     /// <summary>


### PR DESCRIPTION
Checking if the mouse is outside the bounds of the DropDownButton when the PreviewMouseDownOutsideCapturedElement event tunnels through it to prevent the DropDownButton's Popup from closing if the event is caused by a child Popup